### PR TITLE
update to remove netlify from dapp use giveth.io instead

### DIFF
--- a/dapp/js/components/Navigation.jsx
+++ b/dapp/js/components/Navigation.jsx
@@ -7,7 +7,7 @@ export default function Navigation() {
         <Navbar>
             <Navbar.Header>
                 <Navbar.Brand>
-                    <a href="http://giveth.netlify.com">Giveth.io</a>
+                    <a href="http://giveth.io">Giveth.io</a>
                 </Navbar.Brand>
             </Navbar.Header>
             <Nav>


### PR DESCRIPTION
update to remove netlify from dapp use giveth.io instead so that in future we can migrate away from netlify and everything will still work. Also it looks better