### PR TITLE
Inform users when no accounts are found.

### DIFF
--- a/dapp/js/actions/campaignDeployment.js
+++ b/dapp/js/actions/campaignDeployment.js
@@ -55,7 +55,7 @@ export function removeError() {
 }
 
 //show errors on the UI
-function showError(message, stacktrace) {
+export function showError(message, stacktrace) {
     return {
         type: deploymentActions.RUN_ERROR,
         payload: { data: { message, stacktrace } }

--- a/dapp/js/containers/Pages/CampaignDeployer/Component.jsx
+++ b/dapp/js/containers/Pages/CampaignDeployer/Component.jsx
@@ -19,7 +19,11 @@ export default class Deployer extends Component {
   }
 
   componentDidMount() {
-    this.props.setAccount(web3.eth.accounts[0]);
+    if (web3.eth.accounts.length === 0) {
+      this.props.showError('No accounts found. You may need to unlock your MetaMask vault.');
+    } else {
+      this.props.setAccount(web3.eth.accounts[0]);
+    }
     //set default account to user current account if they are not set
     let campaignValues = Object.assign({}, this.props.campaignValues);
     let accountTypes = ['escapeCaller', 'securityGuard', 'donor', 'recipient']
@@ -47,7 +51,12 @@ export default class Deployer extends Component {
 
   //begin the deployment chain.
   runDeployment() {
-    this.props.runDeployment(this.props.userAccount, this.props.campaignValues);
+    if (!this.props.userAccount) {
+      this.props.showError('No accounts found. You must have an unlocked account to be able to deploy a campaign.' +
+        ' You may need to unlock your MetaMask vault.');
+    } else {
+      this.props.runDeployment(this.props.userAccount, this.props.campaignValues);
+    }
   }
 
   cancel() {

--- a/dapp/js/containers/Pages/CampaignDeployer/index.js
+++ b/dapp/js/containers/Pages/CampaignDeployer/index.js
@@ -2,14 +2,14 @@
 import { connect } from 'react-redux';
 import Component from "./Component";
 import { bindActionCreators } from 'redux';
-import { runDeployment, updateCampaignValues, reset, cancel, removeError } from '../../../actions/campaignDeployment';
+import { runDeployment, updateCampaignValues, reset, cancel, removeError, showError } from '../../../actions/campaignDeployment';
 import setAccount from '../../../actions/user';
 
 const mapStateToProps = ({ userAccount, campaignValues, deploymentStatus, deploymentResults, completedDeployments, currentDeploymentStep, error }) =>
                         ({ userAccount, campaignValues, deploymentStatus, deploymentResults, completedDeployments, currentDeploymentStep, error });
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ runDeployment, updateCampaignValues, setAccount, reset, cancel, removeError }, dispatch);
+  return bindActionCreators({ runDeployment, updateCampaignValues, setAccount, reset, cancel, removeError, showError }, dispatch);
 }
 
 const CampaignDeployer = connect(mapStateToProps, mapDispatchToProps)(Component);


### PR DESCRIPTION
Previously in the campaign deployer, there were no checks that accounts
were loaded, which could result in a undefined state being returned from
the reducer. This will happen if your metamask vault is locked.

As a result, the page would look normal except the input fields would
not render correctly on state changes/ user inputs, and was not obvious
what was going on.

This informs the user of the issue.